### PR TITLE
Fix the cleanup logic

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,32 @@
+name: charm-interface-prometheus-scrape
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Lint
+        run: |
+          set -euxo pipefail
+          tox -e pep8
+      - name: Unit tests
+        run: |
+          set -euxo pipefail
+          tox -e py3

--- a/provides.py
+++ b/provides.py
@@ -22,7 +22,6 @@ from charms.reactive import (
 from charmhelpers.core import hookenv
 
 import charmhelpers.contrib.network.ip as ch_net_ip
-import json
 
 
 class PrometheusScrapeProvides(Endpoint):
@@ -91,8 +90,8 @@ class PrometheusScrapeProvides(Endpoint):
             rel.to_publish.pop('prometheus_scrape_unit_address', None)
 
             if hookenv.is_leader():
-                jobs = json.loads(rel.to_publish_app['scrape_jobs'])
-                jobs.pop(job_name, None)
+                jobs = rel.to_publish_app['scrape_jobs']
+                jobs = [j for j in jobs if j['job_name'] != job_name]
                 rel.to_publish_app['scrape_jobs'] = jobs
 
             clear_flag(self.expand_name(

--- a/unit_tests/test_provides.py
+++ b/unit_tests/test_provides.py
@@ -134,3 +134,28 @@ class TestPrometheusScrapeProvides(test_utils.PatchHelper):
             self.relation_mock.to_publish_app,
             expect_app
         )
+
+        # Test the cleanup of the customized jobs as well.
+        self.ep.clear_job('somename')
+
+        expect_app_cleared = {
+            'scrape_jobs': [],
+            'scrape_metadata': {
+                'application': 'myapp',
+                'model': 'mymodel',
+                'model_uuid': '47bfebeb-92ee-4cfa-b768-cd29749d33ac'
+            },
+        }
+
+        self.assertEqual(
+            self.relation_mock.to_publish_raw,
+            expect_unit
+        )
+        self.assertEqual(
+            self.relation_mock.to_publish,
+            {}
+        )
+        self.assertEqual(
+            self.relation_mock.to_publish_app,
+            expect_app_cleared
+        )


### PR DESCRIPTION
## Fix the cleanup logic

Previously it incorrectly assumed a dictionary type where we actually
have a list of dictionaries that needs to be filtered.

This caused hook errors when the clear_job method was called.

## Add github workflows for basic testing
